### PR TITLE
Add a user agent string so we can correctly attribute traffic

### DIFF
--- a/src/oauth.js
+++ b/src/oauth.js
@@ -1,6 +1,6 @@
 import fetch from 'isomorphic-fetch'
 import formurlencoded from 'form-urlencoded'
-import { checkStatus, getJson } from './utils'
+import { checkStatus, getJson, userAgentString } from './utils'
 
 function errMap(err, params) {
     if (err === 'invalid_grant') {
@@ -13,11 +13,12 @@ function errMap(err, params) {
 }
 
 function updateToken(params) {
-    const url = 'https://api.patreon.com/oauth2/token'
+    const url = 'https://www.patreon.com/api/oauth2/token'
     const options = {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+            'User-Agent': userAgentString()
         },
         body: formurlencoded(params),
         params: params,

--- a/src/patreon.js
+++ b/src/patreon.js
@@ -1,6 +1,6 @@
 import fetch from 'isomorphic-fetch'
 import { JsonApiDataStore } from 'jsonapi-datastore'
-import { normalizeRequest, checkStatus, getJson } from './utils'
+import { normalizeRequest, checkStatus, getJson, userAgentString } from './utils'
 
 function patreon(accessToken) {
     let store = new JsonApiDataStore()
@@ -10,7 +10,10 @@ function patreon(accessToken) {
         const url = normalizedRequest.url
         const options = {
             ...normalizedRequest,
-            headers: { Authorization: `Bearer ${accessToken}` },
+            headers: {
+                Authorization: `Bearer ${accessToken}`,
+                'User-Agent': userAgentString()
+            },
             credentials: 'include'
         }
         let _response = undefined

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,8 @@
-const BASE_HOST = 'https://api.patreon.com'
-const BASE_PATH = 'oauth2/api'
+import { version } from '../package.json'
+const os = require('os')
+
+const BASE_HOST = 'https://www.patreon.com'
+const BASE_PATH = 'api/oauth2/api'
 
 function stripPreSlash(str) {
     return str.replace(/^\//, '')
@@ -27,4 +30,8 @@ function getJson(response) {
     return response.json()
 }
 
-export { stripPreSlash, normalizeRequest, checkStatus, getJson }
+function userAgentString() {
+    return `Patreon-JS, version ${version}, platform ${os.platform()}-${os.release()}-${os.arch()}`
+}
+
+export { stripPreSlash, normalizeRequest, checkStatus, getJson, userAgentString }

--- a/tests/oauth.js
+++ b/tests/oauth.js
@@ -38,7 +38,7 @@ test('oauth getTokens', (assert) => {
 
     const { getTokens } = oauth('id', 'secret')
 
-    nock('https://api.patreon.com')
+    nock('https://www.patreon.com/api')
         .post('/oauth2/token')
         .reply(200, function (uri, body) {
             const params = (
@@ -61,7 +61,7 @@ test('oauth getTokens', (assert) => {
             assert.fail('promise failed unexpectedly!')
         })
 
-    nock('https://api.patreon.com')
+    nock('https://www.patreon.com/api')
         .post('/oauth2/token')
         .replyWithError('Oh geeze')
 
@@ -73,7 +73,7 @@ test('oauth getTokens', (assert) => {
             assert.notEqual(err, null, 'err should not be null')
         })
 
-    nock('https://api.patreon.com')
+    nock('https://www.patreon.com/api/')
         .post('/oauth2/token')
         .reply(200, () => { return mockInvalidGrant })
 
@@ -93,7 +93,7 @@ test('oauth getTokens', (assert) => {
 test('oauth refreshToken', (assert) => {
     assert.plan(6)
 
-    nock('https://api.patreon.com')
+    nock('https://www.patreon.com/api')
         .post('/oauth2/token')
         .reply(200, function (uri, body) {
             const params = (
@@ -117,7 +117,7 @@ test('oauth refreshToken', (assert) => {
             assert.fail('promise failed unexpectedly!')
         })
 
-    nock('https://api.patreon.com')
+    nock('https://www.patreon.com/api')
         .post('/oauth2/token')
         .replyWithError('Oh geeze')
 
@@ -129,7 +129,7 @@ test('oauth refreshToken', (assert) => {
             assert.notEqual(err, null, 'err should not be null')
         })
 
-    nock('https://api.patreon.com')
+    nock('https://www.patreon.com/api')
         .post('/oauth2/token')
         .reply(200, () => { return mockInvalidClient })
 

--- a/tests/patreon.js
+++ b/tests/patreon.js
@@ -5,7 +5,7 @@ import patreon from '../src/patreon'
 test('patreon', (assert) => {
     assert.plan(8)
 
-    nock('https://api.patreon.com')
+    nock('https://www.patreon.com/api')
         .get('/oauth2/api/current_user')
         .reply(200, function (uri, body) {
             assert.ok(
@@ -58,7 +58,7 @@ test('patreon', (assert) => {
             assert.fail(err, 'promise failed unexpectedly!')
         })
 
-    nock('https://api.patreon.com')
+    nock('https://www.patreon.com/api')
         .get('/oauth2/api/current_user')
         .replyWithError('Oh geeze')
 

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -13,7 +13,7 @@ test('normalizeRequest', (assert) => {
 
     const requestString = '/nested/request/query'
     assert.deepEqual(normalizeRequest(requestString), {
-        url: 'https://api.patreon.com/oauth2/api/nested/request/query',
+        url: 'https://www.patreon.com/api/oauth2/api/nested/request/query',
         method: 'GET'
     }, 'correctly parses nested request string')
 
@@ -22,7 +22,7 @@ test('normalizeRequest', (assert) => {
         query: 'query'
     }
     assert.deepEqual(normalizeRequest(requestObject), {
-        url: 'https://api.patreon.com/oauth2/api/url',
+        url: 'https://www.patreon.com/api/oauth2/api/url',
         query: 'query'
     }, 'correctly parses request object with url')
 
@@ -31,7 +31,7 @@ test('normalizeRequest', (assert) => {
         query: 'query'
     }
     assert.deepEqual(normalizeRequest(requestObjectWithoutUri), {
-        url: 'https://api.patreon.com/oauth2/api/',
+        url: 'https://www.patreon.com/api/oauth2/api/',
         key: 'value',
         query: 'query'
     }, 'correctly parses request object without url')


### PR DESCRIPTION
Additionally, change the API paths to use our canonical paths.